### PR TITLE
Refactor startsocsim.R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,23 @@
-.Rproj.user
-.Rhistory
-.RData
-.Ruserdata
+# R/Rstudio user- or machine-specific files
+**/*.Rcheck
+**/*.RData
+**/*.Rhistory
+**/*.Rproj
+**/*.Rproj.user
+**/*.Ruserdata
+
+# Documentation. Users should (re-)generate this locally.
+docs/*
+man/*
+**/*.Rd
+
+# Vscode user- or machine-specific files
+.vscode/*
+.vscode/c_cpp_properties.json
+
 src/*.o
 src/*.so
 src/*.dll
-*.log
 src-x64/*
 src-i386/*
-.vscode/c_cpp_properties.json
-docs
-man
-*.Rcheck
-*.Rproj.user
-*.Rd
-man/estimate_fertility_rates.Rd
-man/estimate_mortality_rates.Rd
-man/get_supervisory_content.Rd
-man/read_omar.Rd
-man/read_opop.Rd
-man/simulation_time_to_years.Rd
-man/socsim.Rd
-.vscode/*
+*.log

--- a/R/startsocsim.R
+++ b/R/startsocsim.R
@@ -1,9 +1,4 @@
-#library("future")
-#library(rsocsim)
-
-
-#' Run a single socsim-simulation with a given supervisory-file and folder.
-#' The results will be saved into that folder
+#' Run a single Socsim simulation with a given supervisory file and directory.
 #'
 #' @param folder A string. This is the base directory of the simulation. Every
 #'   .sup and rate file should be named relative to this directory. 
@@ -120,7 +115,6 @@ run1simulationwithfile_future <- function(supfile,seed="42",compatibility_mode="
   return(1)
 }
 
-
 #' Run a socsim-simulation in the r-process
 #'
 #' @param rootfolder rootfolder  name of the simulation
@@ -132,24 +126,6 @@ run1simulationwithfile_inprocess <- function(folder, supfile,seed,compatibility_
   return(1)
 }
 
-
-
-# Deprecated for now!
-#run1simulationwithfile_apply <- function(folder, supfile,seed="23") {
-#  # use the "future" library to run a rcpp-socsim simulation
-#  # in a seperate process
-#  folder = "D:\\dev\\r\\socsimprojects\\CousinDiversity"
-#  supfile = "CousinDiversity.sup"
-#  seed = "23"
-#  numCores=2
-#  cl <- parallel::makeCluster(numCores, type="PSOCK", outfile="")
-#  parallel::clusterExport(cl, run1simulationwithfile_inprocess)
-#  parallel::parLapply(cl,c(2),run1simulationwithfile_inprocess, folder=folder, supfile=supfile,seed=seed)
-#  # now there is a mysterious error: startSocsimWithFile is not available somehow????? 
-#  parallel::stopCluster(cl)
-#  return(1)
-#}
-
 run1simulationwithfile_clustercall <- function(supfile,seed="23",compatibility_mode="1",suffix="") {
   # use the "future" library to run a rcpp-socsim simulation
   # in a seperate process
@@ -160,16 +136,7 @@ run1simulationwithfile_clustercall <- function(supfile,seed="23",compatibility_m
   parallel::clusterExport(cl, "startSocsimWithFile")
   parallel::clusterCall(cl,startSocsimWithFile, supfile=supfile,seed=seed,compatibility_mode=compatibility_mode,result_suffix=suffix)
   print("started!")
-  #print("------------------------------------l4a")
   print_last_line_of_logfile(outfn)
-  #print("------------------------------------l4b")
-  #Sys.sleep(1) 
-  #print_last_line_of_logfile(outfn)
-  #Sys.sleep(1) 
-  #print_last_line_of_logfile(outfn)
-  #Sys.sleep(1) 
-  #print_last_line_of_logfile(outfn)
-  #print("------------------------------------l4c")
   parallel::stopCluster(cl)
   return(1)
 }

--- a/R/startsocsim.R
+++ b/R/startsocsim.R
@@ -26,9 +26,9 @@ socsim <- function(folder, supfile, seed = "42", process_method = "inprocess",
                    compatibility_mode = "1", suffix = "") {
   seed = as.character(seed)
   compatibility_mode = as.character(compatibility_mode)
-  print("Run a single simulation with a given .sup file.")
-  print("Base directory of the simulation:", folder)
-  print("RNG seed:", seed)
+  print("Start running one simulation with a .sup file.")
+  print(paste("Base directory of the simulation:", folder))
+  print(paste("RNG seed:", seed))
   previous_wd = getwd()
   result = NULL
   tryCatch(expr = {

--- a/R/startsocsim.R
+++ b/R/startsocsim.R
@@ -5,36 +5,52 @@
 #' Run a single socsim-simulation with a given supervisory-file and folder.
 #' The results will be saved into that folder
 #'
-#' @param folder base-directory of the simulation. 
-#' Every SUP- and rate-file should be named relative to this folder. 
-#' @param supfile the .sup file to start the simulation, relative to the
-#' folder
-#' @param seed RNG seed as string, Default="42"
-#' @param process_method specify whether and how SOCSIM should be started in its
-#' own process or in the running R process. Use one of
-#'  "inprocess" - SOCSIM runs in the R-process. Beware if you run several different
-#'  simulations - they may affect later simulations
-#'  "future" - the safest option. A new process will be start via the "future"
-#'  package
-#'  "clustercall" - if the future package is not available, try this method instead
-#' @return The results will be written into the specified folder
+#' @param folder A string. This is the base directory of the simulation. Every
+#'   .sup and rate file should be named relative to this directory. 
+#' @param supfile A string. The name of the .sup file to start the simulation,
+#'   relative to the directory.
+#' @param seed A string. The seed for the RNG, so expects an integer. Defaults
+#'   to "42".
+#' @param process_method A string. Whether and how SOCSIM should be started in
+#'   its own process or in the running R process. Defaults to "incprocess". Use
+#'   one of:
+#'    * "future" - the safest option. A new process will be started via the
+#'      "future" package
+#'    * "inprocess" - SOCSIM runs in the R-process. Beware if you run several
+#'      different simulations, they may affect later simulations.
+#'    * "clustercall" - if the future package is not available, try this method
+#'      instead.
+#' @param compatibility_mode A string.
+#' @param suffix A string.
+#' @return Returns the name of the directory to which the results will be
+#'   written.
 #' @export
-socsim <- function(folder, supfile,seed="42",process_method="inprocess",compatibility_mode="1",suffix="") {
-  seed= as.character(seed)
+socsim <- function(folder, supfile, seed = "42", process_method = "inprocess",
+                   compatibility_mode = "1", suffix = "") {
+  seed = as.character(seed)
   compatibility_mode = as.character(compatibility_mode)
-  print("Start run1simulationwithfile")
-  print(folder)
-  print(seed)
+  print("Start running one simulation with a .sup file.")
+  print("Base directory of the simulation:", folder)
+  print("RNG seed:", seed)
   previous_wd = getwd()
   result = NULL
   tryCatch(expr = {
     setwd(folder)
-    if ((process_method=="inprocess") | (process_method =="default")) {
-      result = run1simulationwithfile_inprocess(supfile=supfile,seed=seed,compatibility_mode=compatibility_mode,suffix=suffix)
-    } else if (process_method=="future") {
-      result = run1simulationwithfile_future(supfile=supfile,seed=seed,compatibility_mode=compatibility_mode,suffix=suffix)
-    } else if (process_method=="clustercall") {
-      result = run1simulationwithfile_clustercall(supfile=supfile,seed=seed,compatibility_mode=compatibility_mode,suffix=suffix)
+    if (process_method == "inprocess") {
+      result = run1simulationwithfile_inprocess(supfile = supfile,
+                                                seed = seed,
+                                                compatibility_mode = compatibility_mode,
+                                                suffix = suffix)
+    } else if (process_method == "future") {
+      result = run1simulationwithfile_future(supfile = supfile,
+                                             seed = seed,
+                                             compatibility_mode = compatibility_mode,
+                                             suffix = suffix)
+    } else if (process_method == "clustercall") {
+      result = run1simulationwithfile_clustercall(supfile = supfile, 
+                                                  seed = seed, 
+                                                  compatibility_mode = compatibility_mode,
+                                                  suffix = suffix)
     }
   },
   error = function(w){
@@ -42,7 +58,7 @@ socsim <- function(folder, supfile,seed="42",process_method="inprocess",compatib
     warning(w)
   },
   finally = {
-    print(paste0("restore previous working dir: ", previous_wd))
+    print(paste("Restore previous working dir:", previous_wd))
     setwd(previous_wd)
   }
   )

--- a/R/startsocsim.R
+++ b/R/startsocsim.R
@@ -148,13 +148,13 @@ print_last_line_of_logfile = function(logfilename, lastline = "") {
 #' @return The results will be written into the specified folder
 #' @export
 run1simulationwithfile_from_binary <- function(folder, supfile,seed="42",compatibility_mode="1",socsim_path=NULL) {
-  if (is.null(socsim_path)){
+  if (is.null(socsim_path) || !dir.exists(normalizePath(socsim_path))) {
     print("No socsim_path specified. So I will download the Windows-binary from github to a temporary directory!")
     print("This will probably not work due to antivirus-software.")
     print("please download an executable socsim from https://github.com/tomthe/socsim/releases/download/0.3/socsim.exe")
     print("then save the whole path and specify it as socsim_path for this function!")
     url = "https://github.com/tomthe/socsim/releases/download/0.3/socsim.exe"
-    socsim_path = paste0(tempdir(),"\\","socsim.exe")
+    socsim_path = file.path(tempdir(), "socsim.exe")
     download.file(url,socsim_path,method="auto")
   }
   seed = toString(seed)
@@ -166,7 +166,7 @@ run1simulationwithfile_from_binary <- function(folder, supfile,seed="42",compati
   previous_wd = getwd()
   setwd(paste0(folder))
   
-  print(paste0("command:  ",socsim_path,args=paste0(" ",supfile," ", seed," ", compatibility_mode)))
+  print(paste0("command: ",socsim_path,args=paste0(" ",supfile," ", seed," ", compatibility_mode)))
   
   print(system2(socsim_path,args=c(supfile," ", seed, " ",compatibility_mode)))
   print(system(paste(socsim_path, supfile, seed,compatibility_mode)))

--- a/R/startsocsim.R
+++ b/R/startsocsim.R
@@ -1,6 +1,4 @@
-#' Wrapper for [run_sim_w_file()].
-#'
-#' Run a single Socsim simulation with a given supervisory file and directory.
+#' Run a single Socsim simulation with a given supervisory file and directory
 #'
 #' @param folder A string. This is the base directory of the simulation. Every
 #'   .sup and rate file should be named relative to this directory. 
@@ -135,9 +133,8 @@ print_last_line_of_logfile = function(logfilename, lastline = "") {
   })
 }
 
-#' Run a single socsim-simulation with a socsim binary.
-#' the place
-#' The results will be saved into that folder
+
+#' Run a single socsim-simulation with a socsim binary
 #'
 #' @param rootfolder rootfolder...
 #' @param folder base-directory of the simulation. 
@@ -178,43 +175,48 @@ run1simulationwithfile_from_binary <- function(folder, supfile,seed="42",compati
   return(1)
 }
 
-#' create a folder in the user-dir of the current user in the socsim-subfolder
-#' @param simulation_name optional name for the simulation
-#' @param basefolder optional base directory where the folder will be created
-#' @return the path to the folder
+#' Create a directory structure for the simulation
+#'
+#' Create a two-level directory structure. If the first-level argument is NULL,
+#' we look for and, if needed, created the directory 'socsim' in the user's
+#' home directory. If the second-level argument is NULL, we create a directory
+#' named 'socsim_sim_{some random component}' in the first-level directory.
+#'
+#' @param basedir A string. Optional. First-level directory where the
+#'   simulation-specific directory will be created. Defaults to '$HOME/socsim'.
+#' @param simdir A string. Optional. Simulation-specific directory which will
+#'   be created within 'basedir'. Defaults to 'socsim_sim_' plus a random
+#'   component created with [tempfile()].
+#' @return A string. The full path to the simulation-specific directory.
 #' @export
-create_simulation_folder <- function(simulation_name=NULL,basefolder=NULL) {
-  if (is.null(simulation_name)) {
-    # create a random name that starts with socsim_sim_
-    simulation_name = paste0("socsim_sim_",as.character(sample(1:10000, 1)))
-  }
-  if (is.null(basefolder)) {
-    # check whether there is a "socsim" folder in the users home-directory:
-    # if not, create it
-    userdir <- dirname(path.expand("~//"))
-    basefolder = paste0(userdir, "/", "socsim")
-  }
-  if (!file.exists(basefolder)) {
-    dir.create(basefolder)
-  }
-  # create the subfolder
-  subfolder <- paste0(basefolder, "/", simulation_name)
-  if (!file.exists(subfolder)) {
-    dir.create(subfolder)
-  }
-  return(subfolder)
+create_simulation_folder <- function(basedir = NULL, simdir = NULL) {
+    # If no 'basedir' is given, we default to '$HOME/socsim'.
+    if (is.null(basedir)) { basedir <- file.path(path.expand("~"), "socsim") }
+    # If 'basedir' does not exist, create it.
+    if (!dir.exists(basedir)) { dir.create(basedir) }
+    if (is.null(simdir)) {
+        # If no 'simdir' is given, create a random name that starts with
+        # 'socsim_sim_'.
+        subdir = tempfile(pattern = "socsim_sim_", tmpdir = basedir)
+    } else {
+        subdir = file.path(basedir, simdir)
+    }
+    if (!dir.exists(subdir)) { dir.create(subdir) }
+    return(subdir)
 }
 
-#' create a basic .sup file for a simulation
-#' the simulation is only a simple one
-#' the file will be saved into the sim-folder
-#' @param simfolder the folder where the sup-file will be saved
-#' @param simname the name of the simulation
-#' @return sup.fn the filename of the supervisoryary file
-#' which is needed to start the simulation
+#' Create a basic .sup file for a simulation
+#' 
+#' The simulation is only a simple one. The file will be saved into the
+#' directory 'simdir'.
+#' 
+#' @param simdir A string. The directory where the .sup file will be saved.
+#' @param simname A string. The name of the simulation.
+#' @return A string. The filename of the supervisory file which is needed to
+#'   start the simulation.
 #' @export
-create_sup_file <- function(simfolder, simname) {
-  sup.content <- "
+create_sup_file <- function(simdir, simname) {
+  sup_content <- "
 *Supervisory file for a stable population
 * 20220120
 marriage_queues 1
@@ -229,43 +231,46 @@ include SWEfert2022
 include SWEmort2022
 run
 "
-  sup.fn <- "socsim.sup"
-  cat(sup.content,file=file.path(simfolder, sup.fn))
+  sup_fn <- "socsim.sup"
+  cat(sup_content, file = file.path(simdir, sup_fn))
   fn_SWEfert2022_source <- system.file("extdata", "SWEfert2022", package = "rsocsim", mustWork = TRUE)
-  fn_SWEfert2022_dest <- file.path(simfolder, "SWEfert2022")
+  fn_SWEfert2022_dest <- file.path(simdir, "SWEfert2022")
   fn_SWEmort2022_source <- system.file("extdata", "SWEmort2022", package = "rsocsim", mustWork = TRUE)
-  fn_SWEmort2022_dest <- file.path(simfolder, "SWEmort2022")
+  fn_SWEmort2022_dest <- file.path(simdir, "SWEmort2022")
   fn_init_source <- system.file("extdata", "init_new.opop", package = "rsocsim", mustWork = TRUE)
-  fn_init_dest <- file.path(simfolder, "init_new.opop")
-  file.copy(fn_SWEfert2022_source,fn_SWEfert2022_dest)
-  file.copy(fn_SWEmort2022_source,fn_SWEmort2022_dest)
-  file.copy(fn_init_source,fn_init_dest)
-  return(sup.fn)
+  fn_init_dest <- file.path(simdir, "init_new.opop")
+  file.copy(fn_SWEfert2022_source, fn_SWEfert2022_dest)
+  file.copy(fn_SWEmort2022_source, fn_SWEmort2022_dest)
+  file.copy(fn_init_source, fn_init_dest)
+  return(sup_fn)
 }
 
-#' read the content of the supervisory file 
-#' @param simfolder base folder of the simulation
-#' @param simname name of the .sup-file
-#' @return the content of the supervisory file as a string (TODO: Now it 
-#' returns a list of lines instead of a single string)
+#' Read the content of the supervisory file 
+#'
+#' @param simdir A string. Base directory of the simulation.
+#' @param simname A string. File name of the .sup file.
+#' @return A list of strings. The content of the supervisory file.
 #' @export
-get_supervisory_content <- function(simfolder, sup_fn) {
+get_supervisory_content <- function(simdir, sup_fn) {
   if (is.null(sup_fn)) {
     sup_fn <- "socsim.sup"
   }
-  sup_content <- readLines(file.path(simfolder, sup_fn))
+  sup_content <- readLines(file.path(simdir, sup_fn))
   return(sup_content)
 }
 
-
-
-#' simulation_time_to_years
-#' convert the time measures.
-#' @param simulation time
-#' @param pre-simulation-time - how long the simulation ran to get a stable population
-#' @param start-year - the year the simulation started
-#' @return year, a number like 2022.2
+#' Calculate for how many years the simulation ran
+#'
+#' @param simulation_time An integer. The number of periods (months) the
+#'   simulation ran.
+#' @param pre_simulation_time An integer. The number of periods (months) the
+#'   simulation ran before getting to a stable population. This is subtracted
+#'   from 'simulation_time' in order to arrive at the "real" simulation time
+#' @param start_year An integer. The year the simulation started.
+#' @return An number. The number of years for which the simulation ran. May
+#'   have a fractional part.
 #' @export
 simulation_time_to_years <- function(simulation_time, pre_simulation_time, start_year) {
-  return(start_year + (simulation_time - pre_simulation_time)/12)
+    stopifnot(all(is.integer(simulation_time), is.integer(pre_simulation_time), is.integer(start_year)))
+    return(start_year + (simulation_time - pre_simulation_time)/12)
 }


### PR DESCRIPTION
This includes the other PR (#17) which updates .gitignore.

Fixes a potential bug with `print()`: ce6bf.

Refactors `create_simulation_folder()` (mostly replace paste() with file.path(), normalizePath() etc.).

Refactors `socsim()` and `run1simulationwithfile_*()`: `socsim()` remains a wrapper function but to a single `run*()` function which takes a `method` argument.

Cleans up some formatting. Adds more details to the documentation. Squashes a pet peeve of mine: replace 'folder' with 'directory' in the documentation and variable names.
