### PR TITLE
Issue 20: be more careful with file paths.

### DIFF
--- a/src/src/events.cpp
+++ b/src/src/events.cpp
@@ -272,6 +272,12 @@ int main1(int argc, char *argv[])
 	compatibility_mode = atoi(argv[3]);
 	strcpy(result_suffix, argv[4]);
 	
+
+	// 2024-12-03 Ole
+	// create_output_fn_dir() creates the directory structure for the
+	// simulation and copies some files around. Yes, it uses global state
+	// Yes, ideally it wouldn't. We keep it this way to keep main() simple
+	// and to minimize divergence from the original Socsim.
 	create_output_fn_dir();
 
 	Rcpp::Rcout << "random_number seed: " << ceed << "| command-line argv[1]: " << argv[1] << "| argv[2]: " << argv[2] << std::endl;


### PR DESCRIPTION
Check if provided .sup file name includes '/' or '\'. If so, extract basename. Be more careful when creating file names and file paths inside `create_output_fn_dir()`.

A more comprehensive rework of `create_output_fn_dir()` maybe later.